### PR TITLE
ACNA-474 - Support for additional properties on get, added expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ npm install @adobe/aio-lib-state
   const state = await stateLib.init({ cosmos: { endpoint, masterKey, databaseId, containerId, partitionKey } })
 
   // get
-  const value = await state.get('key')
+  const res = await state.get('key') // res = { value, expiration }
+  const value = res.value
 
   // put
   await state.put('key', 'value')

--- a/doc/api.md
+++ b/doc/api.md
@@ -35,6 +35,7 @@
     * [~AzureCosmosPartitionResourceCredentials](#module_types..AzureCosmosPartitionResourceCredentials) : <code>object</code>
     * [~AzureCosmosMasterCredentials](#module_types..AzureCosmosMasterCredentials) : <code>object</code>
     * [~StateStorePutOptions](#module_types..StateStorePutOptions) : <code>object</code>
+    * [~StateStoreGetReturnValue](#module_types..StateStoreGetReturnValue) : <code>Promise.&lt;object&gt;</code>
     * [~StateLibErrors](#module_types..StateLibErrors) : <code>object</code>
 
 <a name="module_types..OpenWhiskCredentials"></a>
@@ -94,6 +95,19 @@ StateStore put options
 | --- | --- | --- |
 | ttl | <code>number</code> | time-to-live for key-value pair in seconds, defaults to 24 hours (86400s). Set to < 0 for no expiry. A value of 0 sets default. |
 
+<a name="module_types..StateStoreGetReturnValue"></a>
+
+### types~StateStoreGetReturnValue : <code>Promise.&lt;object&gt;</code>
+StateStore get return object
+
+**Kind**: inner typedef of [<code>types</code>](#module_types)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| expiration | <code>string</code> \| <code>null</code> | ISO date string of expiration time for the key-value pair, if the ttl is infinite expiration=null |
+| value | <code>any</code> | the value set by put |
+
 <a name="module_types..StateLibErrors"></a>
 
 ### types~StateLibErrors : <code>object</code>
@@ -120,18 +134,18 @@ Cloud State Management
 **Kind**: global abstract class  
 
 * *[StateStore](#StateStore)*
-    * *[.get(key)](#StateStore+get) ⇒ <code>Promise.&lt;any&gt;</code>*
+    * *[.get(key)](#StateStore+get) ⇒ [<code>StateStoreGetReturnValue</code>](#module_types..StateStoreGetReturnValue)*
     * *[.put(key, value, [options])](#StateStore+put) ⇒ <code>Promise.&lt;string&gt;</code>*
     * *[.delete(key)](#StateStore+delete) ⇒ <code>Promise.&lt;string&gt;</code>*
 
 <a name="StateStore+get"></a>
 
-### *stateStore.get(key) ⇒ <code>Promise.&lt;any&gt;</code>*
+### *stateStore.get(key) ⇒ [<code>StateStoreGetReturnValue</code>](#module_types..StateStoreGetReturnValue)*
 Retrieves the state value for given key.
 If the key doesn't exist returns undefined.
 
 **Kind**: instance method of [<code>StateStore</code>](#StateStore)  
-**Returns**: <code>Promise.&lt;any&gt;</code> - value stored under key or undefined  
+**Returns**: [<code>StateStoreGetReturnValue</code>](#module_types..StateStoreGetReturnValue) - get response holding value and additional info  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -77,7 +77,7 @@ class StateStore {
    * If the key doesn't exist returns undefined.
    *
    * @param {string} key state key identifier
-   * @returns {Promise<any>} value stored under key or undefined
+   * @returns {module:types~StateStoreGetReturnValue} get response holding value and additional info
    * @memberof StateStore
    */
   async get (key) {

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -112,7 +112,13 @@ class CosmosStateStore extends StateStore {
   async _get (key) {
     const response = await _wrap(this._cosmos.container.item(key, this._cosmos.partitionKey).read(), { key })
     // if 404 response.resource = undefined
-    return response.resource && response.resource.value
+    if (!response.resource) return undefined
+    if (response.resource.ttl < 0) {
+      return { value: response.resource.value, expiration: null }
+    }
+
+    const expiration = new Date(response.resource._ts + response.resource.ttl).toISOString()
+    return response.resource && { value: response.resource.value, expiration }
   }
 
   /**

--- a/lib/types.jsdoc.js
+++ b/lib/types.jsdoc.js
@@ -59,6 +59,16 @@ governing permissions and limitations under the License.
  */
 
 /**
+ * StateStore get return object
+ *
+ * @typedef StateStoreGetReturnValue
+ * @type {Promise<object>}
+ * @property {string|null} expiration ISO date string of expiration time for the key-value pair, if the ttl is infinite
+ * expiration=null
+ * @property {any} value the value set by put
+ */
+
+/**
  * @typedef StateLibError
  * @private
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
change get return interface from:
`get(key) => value` to `get(key) => { value, expiration}`

this has the following benefits:
- allow users to know when key-value pair expires
- allows us to add additional get features in the future without breaking interface after 1.0

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
