### PR TITLE
Fix stringification of provider internal error

### DIFF
--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -35,6 +35,10 @@ E('ERROR_PAYLOAD_TOO_LARGE', 'key, value or request payload is too large')
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function logAndThrow (e) {
+  const internalError = e.sdkDetails._internal
+  // by default stringifying an Error returns '{}' because toJSON is not defined, so here we make sure that we properly
+  // stringify the _internal error objects
+  if (internalError && !internalError.toJSON) internalError.toJSON = () => Object.getOwnPropertyNames(internalError).reduce((obj, prop) => { obj[prop] = internalError[prop]; return obj }, {})
   logger.error(JSON.stringify(e, null, 2))
   throw e
 }

--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -38,7 +38,7 @@ function logAndThrow (e) {
   const internalError = e.sdkDetails._internal
   // by default stringifying an Error returns '{}' because toJSON is not defined, so here we make sure that we properly
   // stringify the _internal error objects
-  if (internalError && !internalError.toJSON) internalError.toJSON = () => Object.getOwnPropertyNames(internalError).reduce((obj, prop) => { obj[prop] = internalError[prop]; return obj }, {})
+  if (internalError instanceof Error && !internalError.toJSON) internalError.toJSON = () => Object.getOwnPropertyNames(internalError).reduce((obj, prop) => { obj[prop] = internalError[prop]; return obj }, {})
   logger.error(JSON.stringify(e, null, 2))
   throw e
 }

--- a/test/impl/CosmosStateStore.test.js
+++ b/test/impl/CosmosStateStore.test.js
@@ -58,15 +58,13 @@ beforeEach(async () => {
 async function testProviderErrorHandling (func, mock, fparams) {
   // eslint-disable-next-line jsdoc/require-jsdoc
   async function testOne (status, expectCheck, isInternal, ...addArgs) {
-    const providerError = {
-      code: status,
-      message: 'fakeError'
-    }
+    const providerError = new Error('fakeProviderError')
+    if (status) providerError.code = status
+
     const expectedErrorDetails = { ...fparams }
     if (isInternal) expectedErrorDetails._internal = providerError
     mock.mockReset()
     mock.mockRejectedValue(providerError)
-
     await global[expectCheck](func, ...addArgs, expectedErrorDetails)
   }
 

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -52,6 +52,10 @@ global.expectToThrowCustomError = async (func, code, words, expectedErrorDetails
   }
   expect(err).toBeInstanceOf(Error)
   expect(global.mockLogError).toHaveBeenCalledWith(JSON.stringify(err, null, 2))
+  // here we make sure that the internal error was correctly stringified and that it gets logged
+  if (expectedErrorDetails._internal instanceof Error) {
+    expect(global.mockLogError).toHaveBeenCalledWith(expect.stringContaining(expectedErrorDetails._internal.message))
+  }
 }
 
 global.expectToThrowBadArg = async (received, words, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_BAD_ARGUMENT', words, expectedErrorDetails)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- current logging of underlying provider errors fails because toJSON for Errors is not defined by default
- fix so that _internal shows the error

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
