### PR TITLE
Removing `async` function declarations from `StateStore` class becaus…

### DIFF
--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -91,7 +91,7 @@ class StateStore {
    * @memberof StateStore
    * @private
    */
-  static async init (credentials) { throwNotImplemented('init') }
+  static init (credentials) { throwNotImplemented('init') }
 
   /* **************************** STATE STORE OPERATORS ***************************** */
 
@@ -103,7 +103,7 @@ class StateStore {
    * @returns {Promise<StateStoreGetReturnValue>} get response holding value and additional info
    * @memberof StateStore
    */
-  async get (key) {
+  get (key) {
     validateKey(key, { key })
     logger.debug(`get '${key}'`)
     return this._get(key)
@@ -118,7 +118,7 @@ class StateStore {
    * @returns {Promise<string>} key
    * @memberof StateStore
    */
-  async put (key, value, options = {}) {
+  put (key, value, options = {}) {
     const details = { key, value, options }
     validateKey(key, details)
     validateValue(value, details)
@@ -136,7 +136,7 @@ class StateStore {
    * @returns {Promise<string>} key of deleted state or `null` if state does not exists
    * @memberof StateStore
    */
-  async delete (key) {
+  delete (key) {
     validateKey(key, { key })
     logger.debug(`delete '${key}'`)
     return this._delete(key)


### PR DESCRIPTION
Removing `async` function declarations from abstract `StateStore` class because the functions do not `await` anything such that they'll resolve or reject sooner in time

## Description

The abstract class methods which return async methods of the extended classes (e.g. CosmosStateStore) do not need to be `async` functions because there is no `await` within the abstract calls methods. Removing the `async` declaration removes an unneeded `Promise` in the chain created by calling any of the methods, resulting in the methods resolving or rejecting sooner (at least 1 cpu tick less - can be measurable in some cases).

## Related Issue

Fixes #48 

## Motivation and Context

Random browsing due to github suggestion & noticed the class methods could be refined to be faster.

## How Has This Been Tested?

This doesn't change how things run, so existing tests pass.

## Screenshots (if appropriate):

![Annotation 2020-06-18 074734](https://user-images.githubusercontent.com/369698/85016626-1bbede80-b138-11ea-9238-9c889a5a4616.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
