### PR TITLE
feat: added get all keys feature

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -52,9 +52,11 @@ Cloud State Management
 
 * *[StateStore](#StateStore)*
     * *[.get(key)](#StateStore+get) ⇒ [<code>Promise.&lt;StateStoreGetReturnValue&gt;</code>](#StateStoreGetReturnValue)*
+    * *[.getAllKeys()](#StateStore+getAllKeys) ⇒ <code>Array.&lt;string&gt;</code>*
     * *[.put(key, value, [options])](#StateStore+put) ⇒ <code>Promise.&lt;string&gt;</code>*
     * *[.delete(key)](#StateStore+delete) ⇒ <code>Promise.&lt;string&gt;</code>*
     * *[._get(key)](#StateStore+_get) ⇒ [<code>Promise.&lt;StateStoreGetReturnValue&gt;</code>](#StateStoreGetReturnValue)*
+    * *[._getAllKeys()](#StateStore+_getAllKeys) ⇒ <code>Array.&lt;string&gt;</code>*
     * *[._put(key, value, options)](#StateStore+_put) ⇒ <code>Promise.&lt;string&gt;</code>*
     * *[._delete(key)](#StateStore+_delete) ⇒ <code>Promise.&lt;string&gt;</code>*
 
@@ -71,6 +73,14 @@ If the key doesn't exist returns undefined.
 | --- | --- | --- |
 | key | <code>string</code> | state key identifier |
 
+<a name="StateStore+getAllKeys"></a>
+
+### *stateStore.getAllKeys() ⇒ <code>Array.&lt;string&gt;</code>*
+Retrieves the keys of all stored values.
+If there are no keys returns undefined.
+
+**Kind**: instance method of [<code>StateStore</code>](#StateStore)  
+**Returns**: <code>Array.&lt;string&gt;</code> - Array with all the keys  
 <a name="StateStore+put"></a>
 
 ### *stateStore.put(key, value, [options]) ⇒ <code>Promise.&lt;string&gt;</code>*
@@ -108,6 +118,11 @@ Deletes a state key-value pair
 | --- | --- | --- |
 | key | <code>string</code> | state key identifier |
 
+<a name="StateStore+_getAllKeys"></a>
+
+### *stateStore.\_getAllKeys() ⇒ <code>Array.&lt;string&gt;</code>*
+**Kind**: instance method of [<code>StateStore</code>](#StateStore)  
+**Returns**: <code>Array.&lt;string&gt;</code> - Array with all the keys  
 <a name="StateStore+_put"></a>
 
 ### *stateStore.\_put(key, value, options) ⇒ <code>Promise.&lt;string&gt;</code>*

--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -113,7 +113,7 @@ class StateStore {
    * Retrieves the keys of all stored values.
    * If there are no keys returns undefined.
    *
-   * @returns {Array<String>} Array with all the keys
+   * @returns {Array<string>} Array with all the keys
    * @memberof StateStore
    */
   async getAllKeys () {
@@ -162,10 +162,10 @@ class StateStore {
    */
   async _get (key) { throwNotImplemented('_get') }
   /**
-   * @returns {Array<String>} Array with all the keys
+   * @returns {Array<string>} Array with all the keys
    * @memberof StateStore
    */
-   async _getAllKeys () { throwNotImplemented('_getAllKeys') }
+  async _getAllKeys () { throwNotImplemented('_getAllKeys') }
   /**
    * @param {string} key state key identifier
    * @param {any} value state value

--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -110,6 +110,18 @@ class StateStore {
   }
 
   /**
+   * Retrieves the keys of all stored values.
+   * If there are no keys returns undefined.
+   *
+   * @returns {Array<String>} Array with all the keys
+   * @memberof StateStore
+   */
+  async getAllKeys () {
+    logger.debug('getAllKeys')
+    return this._getAllKeys()
+  }
+
+  /**
    * Creates or updates a state key-value pair
    *
    * @param {string} key state key identifier
@@ -149,6 +161,11 @@ class StateStore {
    * @protected
    */
   async _get (key) { throwNotImplemented('_get') }
+  /**
+   * @returns {Array<String>} Array with all the keys
+   * @memberof StateStore
+   */
+   async _getAllKeys () { throwNotImplemented('_getAllKeys') }
   /**
    * @param {string} key state key identifier
    * @param {any} value state value

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -142,11 +142,9 @@ class CosmosStateStore extends StateStore {
    * @override
    * @private
    */
-   async _getAllKeys () {
+  async _getAllKeys () {
     const options = { partitionKey: this._cosmos.partitionKey }
     const response = await _wrap(this._cosmos.container.items.readAll(options).fetchAll())
-    // if 404 response.resource = undefined
-    if (!response.resources) return undefined
 
     return response.resources.filter((resource) => !!resource.id)
       .reduce((arr, resource) => [...arr, resource.id], [])

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -142,6 +142,21 @@ class CosmosStateStore extends StateStore {
    * @override
    * @private
    */
+   async _getAllKeys () {
+    const options = { partitionKey: this._cosmos.partitionKey }
+    const response = await _wrap(this._cosmos.container.items.readAll(options).fetchAll())
+    // if 404 response.resource = undefined
+    if (!response.resources) return undefined
+
+    return response.resources.filter((resource) => !!resource.id)
+      .reduce((arr, resource) => [...arr, resource.id], [])
+  }
+
+  /**
+   * @memberof CosmosStateStore
+   * @override
+   * @private
+   */
   async _put (key, value, options) {
     const ttl = options.ttl < 0 ? -1 : options.ttl
     await _wrap(this._cosmos.container.items.upsert({ id: key, partitionKey: this._cosmos.partitionKey, ttl, value }), { key, value, options })

--- a/test/StateStore.test.js
+++ b/test/StateStore.test.js
@@ -48,6 +48,21 @@ describe('get', () => {
   })
 })
 
+describe('getAllKeys', () => {
+  // eslint-disable-next-line jest/expect-expect
+  test('missing implementation', async () => {
+    const state = new StateStore(true)
+    await global.expectToThrowNotImplemented(state.getAllKeys.bind(state), '_getAllKeys')
+  })
+  test('calls _getAllKeys (part of interface)', async () => {
+    const state = new StateStore(true)
+    state._getAllKeys = jest.fn()
+    await state.getAllKeys()
+    expect(state._getAllKeys).toHaveBeenCalledTimes(1)
+    expect(global.mockLogDebug).toHaveBeenCalledWith('getAllKeys')
+  })
+})
+
 describe('put', () => {
   // eslint-disable-next-line jest/expect-expect
   test('missing implementation', async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,6 +30,12 @@ export class StateStore {
      */
     get(key: string): Promise<StateStoreGetReturnValue>;
     /**
+     * Retrieves the keys of all stored values.
+     * If there are no keys returns undefined.
+     * @returns Array with all the keys
+     */
+    getAllKeys(): string[];
+    /**
      * Creates or updates a state key-value pair
      * @param key - state key identifier
      * @param value - state value
@@ -49,6 +55,10 @@ export class StateStore {
      */
     protected _get(key: string): Promise<StateStoreGetReturnValue>;
     /**
+     * @returns Array with all the keys
+     */
+    _getAllKeys(): string[];
+    /**
      * @param key - state key identifier
      * @param value - state value
      * @param options - state put options
@@ -62,7 +72,25 @@ export class StateStore {
     protected _delete(key: string): Promise<string>;
 }
 
-
+/**
+ * State lib custom errors.
+ * `e.sdkDetails` provides additional context for each error (e.g. function parameter)
+ * @property ERROR_BAD_ARGUMENT - this error is thrown when an argument is missing or has invalid type
+ * @property ERROR_NOT_IMPLEMENTED - this error is thrown when a method is not implemented or when calling
+ * methods directly on the abstract class (StateStore).
+ * @property ERROR_PAYLOAD_TOO_LARGE - this error is thrown when the state key, state value or underlying request payload size
+ * exceeds the specified limitations.
+ * @property ERROR_BAD_CREDENTIALS - this error is thrown when the supplied init credentials are invalid.
+ * @property ERROR_INTERNAL - this error is thrown when an unknown error is thrown by the underlying
+ * DB provider or TVM server for credential exchange. More details can be found in `e.sdkDetails._internal`.
+ */
+export type StateLibErrors = {
+    ERROR_BAD_ARGUMENT: StateLibError;
+    ERROR_NOT_IMPLEMENTED: StateLibError;
+    ERROR_PAYLOAD_TOO_LARGE: StateLibError;
+    ERROR_BAD_CREDENTIALS: StateLibError;
+    ERROR_INTERNAL: StateLibError;
+};
 
 /**
  * An object holding the OpenWhisk credentials


### PR DESCRIPTION
I added a new API to the store: getAllKeys. It returns the exiting keys for the partition.
Added impl, unit tests, e2e, docs.


## Motivation and Context

We use aio-state-lib for Adobe's AEM Screens Cloud. We need to get all stored keys.
Jira story: http://jira.corp.adobe.com/browse/SCRNS-1287


## How Has This Been Tested?

Added e2e test that passes. Used an AIO runtime namespace

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
