### PR TITLE
[ACNA-1220] Invalid key name leads to obscure error message

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -238,6 +238,7 @@ State lib custom errors.
 | Name | Type | Description |
 | --- | --- | --- |
 | ERROR_BAD_ARGUMENT | <code>StateLibError</code> | this error is thrown when an argument is missing or has invalid type |
+| ERROR_BAD_REQUEST | <code>StateLibError</code> | this error is thrown when an argument has an illegal value. |
 | ERROR_NOT_IMPLEMENTED | <code>StateLibError</code> | this error is thrown when a method is not implemented or when calling methods directly on the abstract class (StateStore). |
 | ERROR_PAYLOAD_TOO_LARGE | <code>StateLibError</code> | this error is thrown when the state key, state value or underlying request payload size exceeds the specified limitations. |
 | ERROR_BAD_CREDENTIALS | <code>StateLibError</code> | this error is thrown when the supplied init credentials are invalid. |

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 /* ************* NOTE 2: requires env vars TEST_AUTH_1, TEST_NS_1 and TEST_AUTH_2, TEST_NS_2 for 2 different namespaces. ************* */
 
 const stateLib = require('../index')
+const { codes } = require('../lib/StateStoreError')
 
 const testKey = 'e2e_test_state_key'
 
@@ -99,6 +100,18 @@ describe('e2e tests using OpenWhisk credentials (as env vars)', () => {
     expect(new Date(res.expiration).getTime()).toBeLessThanOrEqual(new Date(Date.now() + 2000).getTime())
     await waitFor(3000) // give it one more sec - azure ttl is not so precise
     expect(await state.get(testKey)).toEqual(undefined)
+  })
+
+  test('throw error when get/put with invalid keys', async () => {
+    const invalidChars = "The following characters are restricted and cannot be used in the Id property: '/', '\\', '?', '#' "
+    const invalidKey = 'invalid/key'
+    const state = await initStateEnv()
+    await expect(state.put(invalidKey, 'testValue')).rejects.toThrow(new codes.ERROR_BAD_REQUEST({
+      messageValues: [invalidChars]
+    }))
+    await expect(state.get(invalidKey)).rejects.toThrow(new codes.ERROR_BAD_REQUEST({
+      messageValues: [invalidChars]
+    }))
   })
 
   test('isolation tests: get, write, delete on same key for two namespaces do not interfere', async () => {

--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -25,6 +25,7 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-state', { 
  * @typedef StateLibErrors
  * @type {object}
  * @property {StateLibError} ERROR_BAD_ARGUMENT this error is thrown when an argument is missing or has invalid type
+ * @property {StateLibError} ERROR_BAD_REQUEST this error is thrown when an argument has an illegal value.
  * @property {StateLibError} ERROR_NOT_IMPLEMENTED this error is thrown when a method is not implemented or when calling
  * methods directly on the abstract class (StateStore).
  * @property {StateLibError} ERROR_PAYLOAD_TOO_LARGE this error is thrown when the state key, state value or underlying request payload size
@@ -49,6 +50,7 @@ const E = ErrorWrapper(
 )
 
 E('ERROR_INTERNAL', '%s')
+E('ERROR_BAD_REQUEST', '%s')
 E('ERROR_BAD_ARGUMENT', '%s')
 E('ERROR_NOT_IMPLEMENTED', 'method `%s` not implemented')
 E('ERROR_BAD_CREDENTIALS', 'cannot access %s, make sure your credentials are valid')

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -41,6 +41,11 @@ async function _wrap (promise, params) {
     if (status === 413) {
       logAndThrow(new codes.ERROR_PAYLOAD_TOO_LARGE({ sdkDetails: copyParams }))
     }
+    if (e.message.toLowerCase().includes('illegal')) {
+      // e.message is is not as descriptive or consistent.
+      const invalidChars = "The following characters are restricted and cannot be used in the Id property: '/', '\\', '?', '#' "
+      logAndThrow(new codes.ERROR_BAD_REQUEST({ messageValues: [invalidChars], sdkDetails: copyParams }))
+    }
     logAndThrow(new codes.ERROR_INTERNAL({ messageValues: [`unknown error response from provider with status: ${status || 'unknown'}`], sdkDetails: { ...copyParams, _internal: e } }))
   }
   // 404 does not throw in cosmos SDK which is fine as we treat 404 as a non-error,

--- a/test/impl/CosmosStateStore.test.js
+++ b/test/impl/CosmosStateStore.test.js
@@ -56,6 +56,7 @@ beforeEach(async () => {
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 async function testProviderErrorHandling (func, mock, fparams) {
+  const illegalId = "The following characters are restricted and cannot be used in the Id property: '/', '\\', '?', '#' "
   // eslint-disable-next-line jsdoc/require-jsdoc
   async function testOne (status, errorMessage, expectCheck, isInternal, ...addArgs) {
     const providerError = new Error(errorMessage)
@@ -75,6 +76,7 @@ async function testProviderErrorHandling (func, mock, fparams) {
   await testOne(413, 'fakeError', 'expectToThrowTooLarge')
   await testOne(500, 'fakeError', 'expectToThrowInternalWithStatus', true, 500)
   await testOne(undefined, 'fakeError', 'expectToThrowInternal', true)
+  await testOne(undefined, 'contains illegal chars', 'expectToThrowBadRequest', false, [illegalId])
   // when provider resolves with bad status which is not 404
   const providerResponse = {
     statusCode: 400

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -62,6 +62,7 @@ global.expectToThrowCustomError = async (func, code, words, expectedErrorDetails
 }
 
 global.expectToThrowBadArg = async (received, words, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_BAD_ARGUMENT', words, expectedErrorDetails)
+global.expectToThrowBadRequest = async (received, words, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_BAD_REQUEST', words, expectedErrorDetails)
 global.expectToThrowForbidden = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_BAD_CREDENTIALS', ['cannot', 'access', 'credentials'], expectedErrorDetails)
 global.expectToThrowFirewall = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_FIREWALL', ['your', 'IP', 'blocked', 'firewall'], expectedErrorDetails)
 global.expectToThrowInternalWithStatus = async (received, status, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_INTERNAL', ['' + status], expectedErrorDetails)

--- a/types.d.ts
+++ b/types.d.ts
@@ -62,7 +62,27 @@ export class StateStore {
     protected _delete(key: string): Promise<string>;
 }
 
-
+/**
+ * State lib custom errors.
+ * `e.sdkDetails` provides additional context for each error (e.g. function parameter)
+ * @property ERROR_BAD_ARGUMENT - this error is thrown when an argument is missing or has invalid type
+ * @property ERROR_BAD_REQUEST - this error is thrown when an argument has an illegal value.
+ * @property ERROR_NOT_IMPLEMENTED - this error is thrown when a method is not implemented or when calling
+ * methods directly on the abstract class (StateStore).
+ * @property ERROR_PAYLOAD_TOO_LARGE - this error is thrown when the state key, state value or underlying request payload size
+ * exceeds the specified limitations.
+ * @property ERROR_BAD_CREDENTIALS - this error is thrown when the supplied init credentials are invalid.
+ * @property ERROR_INTERNAL - this error is thrown when an unknown error is thrown by the underlying
+ * DB provider or TVM server for credential exchange. More details can be found in `e.sdkDetails._internal`.
+ */
+export type StateLibErrors = {
+    ERROR_BAD_ARGUMENT: StateLibError;
+    ERROR_BAD_REQUEST: StateLibError;
+    ERROR_NOT_IMPLEMENTED: StateLibError;
+    ERROR_PAYLOAD_TOO_LARGE: StateLibError;
+    ERROR_BAD_CREDENTIALS: StateLibError;
+    ERROR_INTERNAL: StateLibError;
+};
 
 /**
  * An object holding the OpenWhisk credentials


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Throw with a custom error message when the provided key is invalid for put and get operations. 
A key is considered invalid if it contains any of the following: '/', '\\', '?', '#'
A custom error message was chosen since the `put` operation returns a really vague message.
put message: `Id contains illegal chars.`
get message: `Illegal characters ['/', '\', '?', '#'] cannot be used in resourceId`


## Related Issue
https://github.com/adobe/aio-lib-state/issues/67

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
