### PR TITLE
fix: put ttl option should throw an error if the value is a quoted number (string)

### DIFF
--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -122,7 +122,7 @@ class StateStore {
     const details = { key, value, options }
     validateKey(key, details)
     validateValue(value, details)
-    validateInput(options, joi.object().label('options').keys({ ttl: joi.number() }), details)
+    validateInput(options, joi.object().label('options').keys({ ttl: joi.number() }).options({ convert: false }), details)
 
     const ttl = options.ttl || StateStore.DefaultTTL // => undefined, null, 0 sets to default
     logger.debug(`put '${key}' with ttl ${ttl}`)

--- a/test/StateStore.test.js
+++ b/test/StateStore.test.js
@@ -66,6 +66,7 @@ describe('put', () => {
     await global.expectToThrowBadArg(state.put.bind(state, 'key', 'value', 'options'), ['object', 'options'], { ...expectedDetails, options: 'options' })
     await global.expectToThrowBadArg(state.put.bind(state, 'key', 'value', { nonexiting__option: 'value' }), ['nonexiting__option', 'not allowed'], { ...expectedDetails, options: { nonexiting__option: 'value' } })
     await global.expectToThrowBadArg(state.put.bind(state, 'key', 'value', { ttl: 'value' }), ['ttl', 'number'], { ...expectedDetails, options: { ttl: 'value' } })
+    await global.expectToThrowBadArg(state.put.bind(state, 'key', 'value', { ttl: '1' }), ['ttl', 'number'], { ...expectedDetails, options: { ttl: '1' } })
   })
   test('calls _put with default ttl when options is undefined or options.ttl is = 0', async () => {
     const state = new StateStore(true)


### PR DESCRIPTION
Fixes #73 

## How Has This Been Tested?

unit test


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
