### PR TITLE
ACNA-961 | add cosmosDB 429 custom error handling

### DIFF
--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -36,7 +36,7 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-state', { 
  * @property {StateLibError} ERROR_BAD_CREDENTIALS this error is thrown when the supplied init credentials are invalid.
  * @property {StateLibError} ERROR_INTERNAL this error is thrown when an unknown error is thrown by the underlying
  * DB provider or TVM server for credential exchange. More details can be found in `e.sdkDetails._internal`.
- * @property {StateLibError} ERROR_DB_RATE_LIMITED this error is thrown when the underlying DB provider is rate limiting the requests
+ * @property {StateLibError} ERROR_REQUEST_RATE_TOO_HIGH this error is thrown when the request rate for accessing state is too high.
  */
 
 const codes = {}
@@ -59,7 +59,7 @@ E('ERROR_BAD_ARGUMENT', '%s')
 E('ERROR_NOT_IMPLEMENTED', 'method `%s` not implemented')
 E('ERROR_BAD_CREDENTIALS', 'cannot access %s, make sure your credentials are valid')
 E('ERROR_PAYLOAD_TOO_LARGE', 'key, value or request payload is too large')
-E('ERROR_DB_RATE_LIMITED', 'db access requests rate limited')
+E('ERROR_REQUEST_RATE_TOO_HIGH', 'Request rate too high. Please retry after sometime.')
 // this error is specific to Adobe's owned database
 E('ERROR_FIREWALL', 'cannot access %s because your IP is blocked by a firewall, please make sure to run in an Adobe I/O Runtime action')
 

--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -36,6 +36,7 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-state', { 
  * @property {StateLibError} ERROR_BAD_CREDENTIALS this error is thrown when the supplied init credentials are invalid.
  * @property {StateLibError} ERROR_INTERNAL this error is thrown when an unknown error is thrown by the underlying
  * DB provider or TVM server for credential exchange. More details can be found in `e.sdkDetails._internal`.
+ * @property {StateLibError} ERROR_DB_RATE_LIMITED this error is thrown when the underlying DB provider is rate limiting the requests
  */
 
 const codes = {}
@@ -58,6 +59,7 @@ E('ERROR_BAD_ARGUMENT', '%s')
 E('ERROR_NOT_IMPLEMENTED', 'method `%s` not implemented')
 E('ERROR_BAD_CREDENTIALS', 'cannot access %s, make sure your credentials are valid')
 E('ERROR_PAYLOAD_TOO_LARGE', 'key, value or request payload is too large')
+E('ERROR_DB_RATE_LIMITED', 'db access requests rate limited')
 // this error is specific to Adobe's owned database
 E('ERROR_FIREWALL', 'cannot access %s because your IP is blocked by a firewall, please make sure to run in an Adobe I/O Runtime action')
 

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -46,6 +46,9 @@ async function _wrap (promise, params) {
       const invalidChars = "The following characters are restricted and cannot be used in the Id property: '/', '\\', '?', '#' "
       logAndThrow(new codes.ERROR_BAD_REQUEST({ messageValues: [invalidChars], sdkDetails: copyParams }))
     }
+    if (status === 429) {
+      logAndThrow(new codes.ERROR_DB_RATE_LIMITED({ messageValues: ['underlying DB provider'], sdkDetails: copyParams }))
+    }
     logAndThrow(new codes.ERROR_INTERNAL({ messageValues: [`unknown error response from provider with status: ${status || 'unknown'}`], sdkDetails: { ...copyParams, _internal: e } }))
   }
   // 404 does not throw in cosmos SDK which is fine as we treat 404 as a non-error,

--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -47,7 +47,7 @@ async function _wrap (promise, params) {
       logAndThrow(new codes.ERROR_BAD_REQUEST({ messageValues: [invalidChars], sdkDetails: copyParams }))
     }
     if (status === 429) {
-      logAndThrow(new codes.ERROR_DB_RATE_LIMITED({ messageValues: ['underlying DB provider'], sdkDetails: copyParams }))
+      logAndThrow(new codes.ERROR_REQUEST_RATE_TOO_HIGH({ sdkDetails: copyParams }))
     }
     logAndThrow(new codes.ERROR_INTERNAL({ messageValues: [`unknown error response from provider with status: ${status || 'unknown'}`], sdkDetails: { ...copyParams, _internal: e } }))
   }

--- a/test/impl/CosmosStateStore.test.js
+++ b/test/impl/CosmosStateStore.test.js
@@ -80,6 +80,7 @@ async function testProviderErrorHandling (func, mock, fparams) {
   await testOne(500, 'fakeError', 'expectToThrowInternalWithStatus', true, 500)
   await testOne(undefined, 'fakeError', 'expectToThrowInternal', true)
   await testOne(undefined, 'contains illegal chars', 'expectToThrowBadRequest', false, [illegalId])
+  await testOne(429, 'fakeError', 'expectToThrowDBRateLimited')
   // when provider resolves with bad status which is not 404
   const providerResponse = {
     statusCode: 400

--- a/test/impl/CosmosStateStore.test.js
+++ b/test/impl/CosmosStateStore.test.js
@@ -80,7 +80,7 @@ async function testProviderErrorHandling (func, mock, fparams) {
   await testOne(500, 'fakeError', 'expectToThrowInternalWithStatus', true, 500)
   await testOne(undefined, 'fakeError', 'expectToThrowInternal', true)
   await testOne(undefined, 'contains illegal chars', 'expectToThrowBadRequest', false, [illegalId])
-  await testOne(429, 'fakeError', 'expectToThrowDBRateLimited')
+  await testOne(429, 'fakeError', 'expectToThrowRequestRateTooHigh')
   // when provider resolves with bad status which is not 404
   const providerResponse = {
     statusCode: 400

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -69,3 +69,4 @@ global.expectToThrowInternalWithStatus = async (received, status, expectedErrorD
 global.expectToThrowInternal = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_INTERNAL', ['unknown'], expectedErrorDetails)
 global.expectToThrowNotImplemented = async (received, methodName) => global.expectToThrowCustomError(received, 'ERROR_NOT_IMPLEMENTED', ['not', 'implemented', methodName], {})
 global.expectToThrowTooLarge = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_PAYLOAD_TOO_LARGE', ['payload', 'is', 'too', 'large'], expectedErrorDetails)
+global.expectToThrowDBRateLimited = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_DB_RATE_LIMITED', ['db', 'access', 'requests', 'rate', 'limited'], expectedErrorDetails)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -69,4 +69,4 @@ global.expectToThrowInternalWithStatus = async (received, status, expectedErrorD
 global.expectToThrowInternal = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_INTERNAL', ['unknown'], expectedErrorDetails)
 global.expectToThrowNotImplemented = async (received, methodName) => global.expectToThrowCustomError(received, 'ERROR_NOT_IMPLEMENTED', ['not', 'implemented', methodName], {})
 global.expectToThrowTooLarge = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_PAYLOAD_TOO_LARGE', ['payload', 'is', 'too', 'large'], expectedErrorDetails)
-global.expectToThrowDBRateLimited = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_DB_RATE_LIMITED', ['db', 'access', 'requests', 'rate', 'limited'], expectedErrorDetails)
+global.expectToThrowRequestRateTooHigh = async (received, expectedErrorDetails) => global.expectToThrowCustomError(received, 'ERROR_REQUEST_RATE_TOO_HIGH', ['Request', 'rate', 'too', 'high'], expectedErrorDetails)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is to wrap the internal cosmosDB 429 error (thrown when more RUs are consumed than provisioned) and throw documented customized error known by state lib. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-lib-state/issues/58
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
