### PR TITLE
fix: validate key characters, throw actionable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Apply when init with OW credentials (and not own cloud DB credentials):
 - Max state key size: `1024 bytes`
 - Max total state size: `10 GB`
 - Token expiry (need to re-init after expiry): `1 hour`
-- Non supported characters for state keys are: `'/', '\\', '?', '#'`
+- Non supported characters for state keys are: `'/', '\', '?', '#'`
 
 ## Adobe I/O State Store Consistency Guarantees
 

--- a/lib/StateStore.js
+++ b/lib/StateStore.js
@@ -55,7 +55,9 @@ function validateInput (input, schema, details) {
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function validateKey (key, details, label = 'key') {
-  validateInput(key, joi.string().label(label).required(), details)
+  validateInput(key, joi.string().label(label).required().regex(/[?#/\\]/, { invert: true }).messages({
+    'string.pattern.invert.base': 'Key cannot contain ?, #, /, or \\'
+  }), details)
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc

--- a/lib/StateStoreError.js
+++ b/lib/StateStoreError.js
@@ -27,7 +27,7 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-state', { 
  *
  * @typedef StateLibErrors
  * @type {object}
- * @property {StateLibError} ERROR_BAD_ARGUMENT this error is thrown when an argument is missing or has invalid type
+ * @property {StateLibError} ERROR_BAD_ARGUMENT this error is thrown when an argument is missing, has invalid type, or includes invalid characters.
  * @property {StateLibError} ERROR_BAD_REQUEST this error is thrown when an argument has an illegal value.
  * @property {StateLibError} ERROR_NOT_IMPLEMENTED this error is thrown when a method is not implemented or when calling
  * methods directly on the abstract class (StateStore).

--- a/test/StateStore.test.js
+++ b/test/StateStore.test.js
@@ -38,6 +38,14 @@ describe('get', () => {
     const state = new StateStore(true)
     await global.expectToThrowBadArg(state.get.bind(state, 123), ['string', 'key'], { key: 123 })
   })
+  // eslint-disable-next-line jest/expect-expect
+  test('bad key characters', async () => {
+    const state = new StateStore(true)
+    await global.expectToThrowBadArg(state.put.bind(state, '?test', 'value', {}), ['Key', 'cannot', 'contain'], { key: '?test', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't#est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't#est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't\\est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't\\est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 'test/', 'value', {}), ['Key', 'cannot', 'contain'], { key: 'test/', value: 'value', options: {} })
+  })
   test('calls _get (part of interface)', async () => {
     const state = new StateStore(true)
     state._get = jest.fn()
@@ -58,6 +66,14 @@ describe('put', () => {
   test('bad key type', async () => {
     const state = new StateStore(true)
     await global.expectToThrowBadArg(state.put.bind(state, 123, 'value', {}), ['string', 'key'], { key: 123, value: 'value', options: {} })
+  })
+  // eslint-disable-next-line jest/expect-expect
+  test('bad key characters', async () => {
+    const state = new StateStore(true)
+    await global.expectToThrowBadArg(state.put.bind(state, '?test', 'value', {}), ['Key', 'cannot', 'contain'], { key: '?test', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't#est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't#est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't\\est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't\\est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 'test/', 'value', {}), ['Key', 'cannot', 'contain'], { key: 'test/', value: 'value', options: {} })
   })
   // eslint-disable-next-line jest/expect-expect
   test('bad options', async () => {
@@ -101,6 +117,14 @@ describe('delete', () => {
   test('bad key type', async () => {
     const state = new StateStore(true)
     await global.expectToThrowBadArg(state.delete.bind(state, 123), ['string', 'key'], { key: 123 })
+  })
+  // eslint-disable-next-line jest/expect-expect
+  test('bad key characters', async () => {
+    const state = new StateStore(true)
+    await global.expectToThrowBadArg(state.put.bind(state, '?test', 'value', {}), ['Key', 'cannot', 'contain'], { key: '?test', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't#est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't#est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 't\\est', 'value', {}), ['Key', 'cannot', 'contain'], { key: 't\\est', value: 'value', options: {} })
+    await global.expectToThrowBadArg(state.put.bind(state, 'test/', 'value', {}), ['Key', 'cannot', 'contain'], { key: 'test/', value: 'value', options: {} })
   })
   test('calls _delete (part of interface)', async () => {
     const state = new StateStore(true)


### PR DESCRIPTION
## Description

* Validate keys against regex, disallow `?`, `#`, `/`, `\`
* Throw actionable error

## Related Issue

Closes https://github.com/adobe/aio-lib-state/issues/86

## How Has This Been Tested?

Locally linked aio-lib-state in action, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
