### PR TITLE
fix: clear instance cache for init with fresh credentials

### DIFF
--- a/lib/impl/CosmosStateStore.js
+++ b/lib/impl/CosmosStateStore.js
@@ -73,12 +73,13 @@ class CosmosStateStore extends StateStore {
    * @override
    * @private
    */
-  constructor (container, partitionKey) {
+  constructor (container, partitionKey, /* istanbul ignore next */ options = { expiration: null }) {
     super()
     /** @private */
     this._cosmos = {}
     this._cosmos.container = container
     this._cosmos.partitionKey = partitionKey
+    this.expiration = options.expiration
   }
 
   /**
@@ -102,7 +103,7 @@ class CosmosStateStore extends StateStore {
       containerId: joi.string().required(),
       partitionKey: joi.string().required(),
 
-      expiration: joi.string() // allowed for tvm response
+      expiration: joi.string() // allowed for tvm response, in ISO format
     }).xor('masterKey', 'resourceToken').required()
       .validate(credentials)
     if (validation.error) {
@@ -112,9 +113,16 @@ class CosmosStateStore extends StateStore {
       }))
     }
 
+    const inMemoryInstance = CosmosStateStore.inMemoryInstance[credentials.partitionKey]
+    if (inMemoryInstance && inMemoryInstance.expiration !== credentials.expiration) {
+      // the TVM credentials have changed, aio-lib-core-tvm has generated new one likely because of expiration.
+      delete CosmosStateStore.inMemoryInstance[credentials.partitionKey]
+    }
+
     if (!CosmosStateStore.inMemoryInstance[credentials.partitionKey]) {
       let cosmosClient
       if (credentials.resourceToken) {
+        // Note: resourceToken doesn't necessarily mean that the TVM provided the credentials, it can have been provided by a user.
         logger.debug('using azure cosmos resource token')
         cosmosClient = new cosmos.CosmosClient({ endpoint: credentials.endpoint, consistencyLevel: 'Session', tokenProvider: /* istanbul ignore next */ async () => credentials.resourceToken })
       } else {
@@ -125,7 +133,7 @@ class CosmosStateStore extends StateStore {
         // container = (await database.containers.createIfNotExists({ id: credentials.containerId })).container
       }
       const container = cosmosClient.database(credentials.databaseId).container(credentials.containerId)
-      CosmosStateStore.inMemoryInstance[credentials.partitionKey] = new CosmosStateStore(container, credentials.partitionKey)
+      CosmosStateStore.inMemoryInstance[credentials.partitionKey] = new CosmosStateStore(container, credentials.partitionKey, { expiration: credentials.expiration })
     } else {
       logger.debug('reusing exising in-memory CosmosClient initialization')
     }

--- a/lib/init.js
+++ b/lib/init.js
@@ -88,8 +88,6 @@ async function wrapTVMRequest (promise, params) {
  * @returns {Promise<StateStore>} A StateStore instance
  */
 async function init (config = {}) {
-  // todo joi-validate config here or leave it to StateStore impl + TvmClient?
-
   // 0. log
   const logConfig = utils.withHiddenFields(config, ['ow.auth', 'cosmos.resourceToken', 'cosmos.masterKey'])
 

--- a/test/impl/CosmosStateStore.test.js
+++ b/test/impl/CosmosStateStore.test.js
@@ -181,6 +181,7 @@ describe('init', () => {
         expect(cosmos.CosmosClient).toHaveBeenCalledTimes(0)
       })
       test('successive calls should reuse the CosmosStateStore instance - with masterkey', async () => {
+        // note this test may be confusing as no reuse is made with BYO credentials, but the cache is actually deleted by the top level init file. See test below.
         await testInitOK(fakeCosmosMasterCredentials)
         expect(cosmos.CosmosClient).toHaveBeenCalledTimes(1)
         cosmos.CosmosClient.mockReset()
@@ -193,6 +194,17 @@ describe('init', () => {
         await stateLib.init({ cosmos: fakeCosmosMasterCredentials })
         // New CosmosClient instance generated again
         expect(cosmos.CosmosClient).toHaveBeenCalledTimes(2)
+      })
+      test('No reuse if TVM credential expiration changed', async () => {
+        await testInitOK(fakeCosmosTVMResponse)
+        expect(cosmos.CosmosClient).toHaveBeenCalledTimes(1)
+        await CosmosStateStore.init({ ...fakeCosmosTVMResponse, expiration: new Date(0).toISOString() })
+        expect(cosmos.CosmosClient).toHaveBeenCalledTimes(2)
+        await CosmosStateStore.init({ ...fakeCosmosTVMResponse, expiration: new Date(1).toISOString() })
+        expect(cosmos.CosmosClient).toHaveBeenCalledTimes(3)
+        // double check, same credentials no additional call
+        await CosmosStateStore.init({ ...fakeCosmosTVMResponse, expiration: new Date(1).toISOString() })
+        expect(cosmos.CosmosClient).toHaveBeenCalledTimes(3)
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

when State is used in a runtime action this is what happens

```
async function main() {
  const state = await State.init()
  const value = await state.get('mykey')
}
```

First invocation of main:
1. State calls `aio-lib-core-tvm` init which fetches credentials from TVM.
2. `aio-lib-core-tvm` caches credentials
3. State inits the `CosmosStateStore` instance 
4. State stores the instance in the `CosmosStateStore.inMemoryInstance` object
5. `state.get` uses the gets the key using cosmos credentials

Subsequent invocations:
1. `init()` calls `aio-lib-core-tvm` init which: (a) either returns the cached credentials or (b) if the credentials are expired fetches new ones
2. State reuses the `CosmosStateStore` instance even if the credentials are expired
3. `state.get` fails if the credentials are expired.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
