### PR TITLE
feat: dockerize e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+e2e/.env

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -1,0 +1,1 @@
+FROM node:20 AS build-envCOPY . /appWORKDIR /appRUN npm iFROM gcr.io/distroless/nodejs20-debian11COPY --from=build-env /app /appWORKDIR /appCMD ["node_modules/jest/bin/jest.js", "-c", "jest.e2e.config.js"]

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -1,1 +1,10 @@
-FROM node:20 AS build-envCOPY . /appWORKDIR /appRUN npm iFROM gcr.io/distroless/nodejs20-debian11COPY --from=build-env /app /appWORKDIR /appCMD ["node_modules/jest/bin/jest.js", "-c", "jest.e2e.config.js"]
+FROM node:20 AS build-env
+COPY . /app
+WORKDIR /app
+
+RUN npm i
+
+FROM gcr.io/distroless/nodejs20-debian11
+COPY --from=build-env /app /app
+WORKDIR /app
+CMD ["node_modules/jest/bin/jest.js", "-c", "jest.e2e.config.js"]

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -2,4 +2,5 @@ TEST_NAMESPACE_1='11111-test'
 TEST_AUTH_1='testauth'
 TEST_AUTH_2='testauth2'
 TEST_NAMESPACE_2='12345-test-stage'
+# do not use the scheme for endpoints
 ADOBE_STATE_STORE_ENDPOINT_PROD='127.0.0.1:8080'

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -39,6 +39,13 @@ const initStateEnv = async (n = 1) => {
 
 const waitFor = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
+test('env vars', () => {
+  expect(process.env.TEST_AUTH_1).toBeDefined()
+  expect(process.env.TEST_AUTH_2).toBeDefined()
+  expect(process.env.TEST_NAMESPACE_1).toBeDefined()
+  expect(process.env.TEST_NAMESPACE_2).toBeDefined()
+})
+
 describe('e2e tests using OpenWhisk credentials (as env vars)', () => {
   test('error bad credentials test: auth is ok but namespace is not', async () => {
     delete process.env.__OW_API_KEY

--- a/e2e/e2e.md
+++ b/e2e/e2e.md
@@ -27,7 +27,9 @@ Substitute the host with `host.docker.internal` if you are testing with the Dock
 
 ```sh
 # build the Docker image
-docker build -f e2e.Dockerfile -t aio-lib-state-e2e .
+# multi-arch build: see https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images
+docker buildx create --name mybuilder --bootstrap --use
+docker buildx build -f e2e.Dockerfile --platform linux/arm/v7,linux/arm64/v8,linux/amd64 -t aio-lib-state-e2e --load .
 # create and run a container based off the Docker image, pass in the environment file
 docker run --env-file e2e/.env -t aio-lib-state-e2e
 ```

--- a/e2e/e2e.md
+++ b/e2e/e2e.md
@@ -10,9 +10,27 @@
 
 Copy the `.env.example` to your own `.env` in this folder.
 
-## Run
+For local testing, add the environment variable:
+
+```sh
+# do not use the scheme for endpoints
+ADOBE_STATE_STORE_ENDPOINT_PROD=127.0.0.1:8080
+```
+
+Substitute the host with `host.docker.internal` if you are testing with the Dockerized version of the e2e tests.
+
+## Local Run
 
 `npm run e2e`
+
+## Docker Run
+
+```sh
+# build the Docker image
+docker build -f e2e.Dockerfile -t aio-lib-state-e2e .
+# create and run a container based off the Docker image, pass in the environment file
+docker run --env-file e2e/.env -t aio-lib-state-e2e
+```
 
 ## Test overview
 

--- a/lib/AdobeState.js
+++ b/lib/AdobeState.js
@@ -145,7 +145,7 @@ class AdobeState {
    * @returns {string} the constructed request url
    */
   createRequestUrl (key, queryObject = {}) {
-    const isLocal = this.endpoint.startsWith('localhost') || this.endpoint.startsWith('127.0.0.1')
+    const isLocal = this.endpoint.startsWith('localhost') || this.endpoint.startsWith('127.0.0.1') || this.endpoint.startsWith('host.docker.internal')
     const protocol = isLocal ? 'http' : 'https'
     const regionSubdomain = isLocal ? '' : `${this.region}.`
     let urlString


### PR DESCRIPTION
## Motivation and Context

For ease of e2e testing, for canary deploys.

## How Has This Been Tested?

- create e2e/.env (see .env.example)
- run the local server (see internal adp-storage-state repo, requires a modification to add the second test namespace)
- npm run e2e (to verify it works first), then
- run the e2e via docker (see e2e/e2e.md)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
