### PR TITLE
fix: add Github workflow to publish e2e Docker image

### DIFF
--- a/.github/workflows/publish-docker-image-e2e.yml
+++ b/.github/workflows/publish-docker-image-e2e.yml
@@ -28,4 +28,4 @@ jobs:
           context: .
           file: e2e.Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}/e2e-tests:${{ github.event.inputs.tag }}
+          tags: ghcr.io/${{ github.repository }}/aio-lib-state-e2e-tests:${{ github.event.inputs.tag }}

--- a/.github/workflows/publish-docker-image-e2e.yml
+++ b/.github/workflows/publish-docker-image-e2e.yml
@@ -1,0 +1,31 @@
+name: Publish Docker Image (e2e tests)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker Tag'
+        required: true
+        default: 'latest'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: e2e.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/e2e-tests:${{ github.event.inputs.tag }}

--- a/e2e/e2e.md
+++ b/e2e/e2e.md
@@ -19,6 +19,28 @@ ADOBE_STATE_STORE_ENDPOINT_PROD=127.0.0.1:8080
 
 Substitute the host with `host.docker.internal` if you are testing with the Dockerized version of the e2e tests.
 
+## Canary Testing
+
+You might have to connect to internal servers for your e2e testing.
+
+For `prod`, use these two environment variables:
+
+```sh
+# do not use the scheme for endpoints
+ADOBE_STATE_STORE_ENDPOINT_PROD=my-prod-server-here.com
+# can be omitted as well, since it defaults to prod
+AIO_CLI_ENV=prod
+```
+
+For `stage`, use these two environment variables:
+
+```sh
+# do not use the scheme for endpoints
+ADOBE_STATE_STORE_ENDPOINT_STAGE=my-stage-server-here.com
+# set the env
+AIO_CLI_ENV=stage
+```
+
 ## Local Run
 
 `npm run e2e`


### PR DESCRIPTION
On-demand Github workflow to publish to Github Packages. Docker tag is `latest` by default.
The docker image will eventually be listed under the `Packages` section of this repo: https://github.com/orgs/adobe/packages?repo_name=aio-lib-state

## How Has This Been Tested?

Needs to be merged for the final test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
