### PR TITLE
fix: add ADOBE_STATE_STORE_REGION env var support for the e2e tests

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -4,3 +4,4 @@ TEST_AUTH_2='testauth2'
 TEST_NAMESPACE_2='12345-test-stage'
 # do not use the scheme for endpoints
 ADOBE_STATE_STORE_ENDPOINT_PROD='127.0.0.1:8080'
+ADOBE_STATE_STORE_REGION=amer

--- a/e2e/e2e.md
+++ b/e2e/e2e.md
@@ -23,22 +23,27 @@ Substitute the host with `host.docker.internal` if you are testing with the Dock
 
 You might have to connect to internal servers for your e2e testing.
 
-For `prod`, use these two environment variables:
+For `prod`, use these three environment variables:
 
 ```sh
 # do not use the scheme for endpoints
 ADOBE_STATE_STORE_ENDPOINT_PROD=my-prod-server-here.com
-# can be omitted as well, since it defaults to prod
+# set the env, if omitted, defaults to 'prod'
 AIO_CLI_ENV=prod
+# set the region, if omitted, defaults to 'amer'
+ADOBE_STATE_STORE_REGION=emea
+
 ```
 
-For `stage`, use these two environment variables:
+For `stage`, use these three environment variables:
 
 ```sh
 # do not use the scheme for endpoints
 ADOBE_STATE_STORE_ENDPOINT_STAGE=my-stage-server-here.com
 # set the env
 AIO_CLI_ENV=stage
+# set the region, if omitted, defaults to 'amer'
+ADOBE_STATE_STORE_REGION=emea
 ```
 
 ## Local Run

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const stateLib = require('../index')
+const { ADOBE_STATE_STORE_REGIONS } = require('../lib/constants')
 
 describe('init', () => {
   const env = process.env
@@ -45,5 +46,19 @@ describe('init', () => {
 
     expect(store.namespace).toEqual(process.env.__OW_NAMESPACE)
     expect(store.apikey).toEqual(process.env.__OW_API_KEY)
+    expect(store.region).toEqual(ADOBE_STATE_STORE_REGIONS.at(0))
+  })
+
+  test('when config.region is set, OW creds as env variables', async () => {
+    process.env.__OW_NAMESPACE = 'some-namespace'
+    process.env.__OW_API_KEY = 'some-api-key'
+    const region = 'emea'
+
+    expect.hasAssertions()
+    const store = await stateLib.init({ region })
+
+    expect(store.namespace).toEqual(process.env.__OW_NAMESPACE)
+    expect(store.apikey).toEqual(process.env.__OW_API_KEY)
+    expect(store.region).toEqual(region)
   })
 })


### PR DESCRIPTION
For the e2e tests, we need a way to support setting the region of the ADP State Server.
The env var `ADOBE_STATE_STORE_REGION` has been added for the e2e tests only.

## How Has This Been Tested?

- npm run e2e on a local adp-state server (with two mock namespaces)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
