### PR TITLE
fix!: hide 404s on container operations

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -61,9 +61,9 @@ Cloud State Management
     * *[.get(key)](#AdobeState+get) ⇒ [<code>Promise.&lt;AdobeStateGetReturnValue&gt;</code>](#AdobeStateGetReturnValue)*
     * *[.put(key, value, [options])](#AdobeState+put) ⇒ <code>Promise.&lt;string&gt;</code>*
     * *[.delete(key)](#AdobeState+delete) ⇒ <code>Promise.&lt;(string\|null)&gt;</code>*
-    * *[.deleteAll(options)](#AdobeState+deleteAll) ⇒ <code>Promise.&lt;({keys: number}\|null)&gt;</code>*
+    * *[.deleteAll(options)](#AdobeState+deleteAll) ⇒ <code>Promise.&lt;{keys: number}&gt;</code>*
     * *[.any()](#AdobeState+any) ⇒ <code>Promise.&lt;boolean&gt;</code>*
-    * *[.stats()](#AdobeState+stats) ⇒ <code>Promise.&lt;({bytesKeys: number, bytesValues: number, keys: number}\|null)&gt;</code>*
+    * *[.stats()](#AdobeState+stats) ⇒ <code>Promise.&lt;{bytesKeys: number, bytesValues: number, keys: number}&gt;</code>*
     * *[.list(options)](#AdobeState+list) ⇒ <code>AsyncGenerator.&lt;{keys: Array.&lt;string&gt;}&gt;</code>*
 
 <a name="AdobeState+getRegionalEndpoint"></a>
@@ -120,12 +120,12 @@ Deletes a state key-value pair
 
 <a name="AdobeState+deleteAll"></a>
 
-### *adobeState.deleteAll(options) ⇒ <code>Promise.&lt;({keys: number}\|null)&gt;</code>*
+### *adobeState.deleteAll(options) ⇒ <code>Promise.&lt;{keys: number}&gt;</code>*
 Deletes multiple key-values. The match option is required as a safeguard.
 CAUTION: use `{ match: '*' }` to delete all key-values.
 
 **Kind**: instance method of [<code>AdobeState</code>](#AdobeState)  
-**Returns**: <code>Promise.&lt;({keys: number}\|null)&gt;</code> - returns an object with the number of deleted keys or `null` if the container is empty.  
+**Returns**: <code>Promise.&lt;{keys: number}&gt;</code> - returns an object with the number of deleted keys.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -145,11 +145,11 @@ There exists key-values in the region.
 **Returns**: <code>Promise.&lt;boolean&gt;</code> - true if exists, false if not  
 <a name="AdobeState+stats"></a>
 
-### *adobeState.stats() ⇒ <code>Promise.&lt;({bytesKeys: number, bytesValues: number, keys: number}\|null)&gt;</code>*
+### *adobeState.stats() ⇒ <code>Promise.&lt;{bytesKeys: number, bytesValues: number, keys: number}&gt;</code>*
 Get stats.
 
 **Kind**: instance method of [<code>AdobeState</code>](#AdobeState)  
-**Returns**: <code>Promise.&lt;({bytesKeys: number, bytesValues: number, keys: number}\|null)&gt;</code> - namespace stats or `null` if there are no keys in the container.  
+**Returns**: <code>Promise.&lt;{bytesKeys: number, bytesValues: number, keys: number}&gt;</code> - State container stats.  
 <a name="AdobeState+list"></a>
 
 ### *adobeState.list(options) ⇒ <code>AsyncGenerator.&lt;{keys: Array.&lt;string&gt;}&gt;</code>*

--- a/lib/AdobeState.js
+++ b/lib/AdobeState.js
@@ -418,7 +418,7 @@ class AdobeState {
    *  await state.deleteAll({ match: 'abc*' })
    * @param {object} options deleteAll options.
    * @param {string} options.match REQUIRED, a glob pattern to specify which keys to delete.
-   * @returns {Promise<{ keys: number }|null>} returns an object with the number of deleted keys or `null` if the container is empty.
+   * @returns {Promise<{ keys: number }>} returns an object with the number of deleted keys.
    * @memberof AdobeState
    */
   async deleteAll (options = {}) {
@@ -453,7 +453,7 @@ class AdobeState {
     const response = await _wrap(promise, {})
 
     if (response.status === 404) {
-      return null
+      return { keys: 0 }
     } else {
       const { keys } = await response.json()
       return { keys }
@@ -484,7 +484,7 @@ class AdobeState {
   /**
    * Get stats.
    *
-   * @returns {Promise<{ bytesKeys: number, bytesValues: number, keys: number} | null>} namespace stats or `null` if there are no keys in the container.
+   * @returns {Promise<{ bytesKeys: number, bytesValues: number, keys: number }>} State container stats.
    * @memberof AdobeState
    */
   async stats () {
@@ -500,7 +500,7 @@ class AdobeState {
     const promise = this.fetchRetry.exponentialBackoff(this.createRequestUrl(), requestOptions)
     const response = await _wrap(promise, {})
     if (response.status === 404) {
-      return null
+      return { keys: 0, bytesKeys: 0, bytesValues: 0 }
     } else {
       const { keys, bytesKeys, bytesValues } = await response.json()
       return { keys, bytesKeys, bytesValues }

--- a/test/AdobeState.test.js
+++ b/test/AdobeState.test.js
@@ -413,7 +413,7 @@ describe('deleteAll', () => {
     mockExponentialBackoff.mockResolvedValue(wrapInFetchError(404))
 
     const value = await store.deleteAll({ match: '*' })
-    expect(value).toEqual(null)
+    expect(value).toEqual({ keys: 0 })
   })
 })
 
@@ -442,7 +442,7 @@ describe('stats()', () => {
     mockExponentialBackoff.mockResolvedValue(wrapInFetchError(404))
 
     const value = await store.stats()
-    expect(value).toEqual(null)
+    expect(value).toEqual({ keys: 0, bytesValues: 0, bytesKeys: 0 })
   })
 })
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -70,11 +70,11 @@ export class AdobeState {
      * await state.deleteAll({ match: 'abc*' })
      * @param options - deleteAll options.
      * @param options.match - REQUIRED, a glob pattern to specify which keys to delete.
-     * @returns returns an object with the number of deleted keys or `null` if the container is empty.
+     * @returns returns an object with the number of deleted keys.
      */
     deleteAll(options: {
         match: string;
-    }): Promise<{ keys: number; } | null>;
+    }): Promise<{ keys: number; }>;
     /**
      * There exists key-values in the region.
      * @returns true if exists, false if not
@@ -82,9 +82,9 @@ export class AdobeState {
     any(): Promise<boolean>;
     /**
      * Get stats.
-     * @returns namespace stats or `null` if there are no keys in the container.
+     * @returns State container stats.
      */
-    stats(): Promise<{ bytesKeys: number; bytesValues: number; keys: number; } | null>;
+    stats(): Promise<{ bytesKeys: number; bytesValues: number; keys: number; }>;
     /**
      * List keys, returns an iterator. Every iteration returns a batch of
      * approximately `countHint` keys.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

MAJOR change, to be merged on #174 

Container operations on the server return a 404 when the State container is empty (no key values), let's simplify the process on the client and return `keys: 0` on `stats` and `deleteAll` operations. This way users do not need to add an extra `if (!null)` branch.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
