### PR TITLE
Use __OW_CLOUD to detect internal/runtime

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,8 +49,8 @@ function withHiddenFields (sourceObj, fieldsToHide) {
  * @returns {boolean} returns true if in Adobe Runtime
  */
 function isInternalToAdobeRuntime () {
-  const { __OW_NAMESPACE, __OW_API_HOST, __OW_ACTIVATION_ID } = process.env
-  return !!(__OW_NAMESPACE && __OW_API_HOST && __OW_ACTIVATION_ID)
+  const { __OW_CLOUD } = process.env
+  return !!(__OW_CLOUD)
 }
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -55,26 +55,17 @@ describe('isInternalToAdobeRuntime', () => {
   })
 
   test('in runtime context', () => {
-    process.env.__OW_NAMESPACE = 'some-namespace'
-    process.env.__OW_API_HOST = 'some-server-dot-com'
-    process.env.__OW_ACTIVATION_ID = 'some-activation-id'
-
+    process.env.__OW_CLOUD = 'aws'
     expect(isInternalToAdobeRuntime()).toBeTruthy()
   })
 
   test('not in runtime context', () => {
-    // make doubly sure the env vars are not there
-    delete process.env.__OW_NAMESPACE
-    delete process.env.__OW_API_HOST
-    delete process.env.__OW_ACTIVATION_ID
-
+    process.env.__OW_CLOUD = undefined
     expect(isInternalToAdobeRuntime()).toBeFalsy()
   })
 
   test('in runtime context - endpoints should be internal', () => {
-    process.env.__OW_NAMESPACE = 'some-namespace'
-    process.env.__OW_API_HOST = 'some-server-dot-com'
-    process.env.__OW_ACTIVATION_ID = 'some-activation-id'
+    process.env.__OW_CLOUD = 'aws'
 
     expect(isInternalToAdobeRuntime()).toBeTruthy()
     jest.isolateModules(() => {
@@ -85,16 +76,24 @@ describe('isInternalToAdobeRuntime', () => {
   })
 
   test('not in runtime context - endpoints should be public', () => {
-    // make doubly sure the env vars are not there
-    delete process.env.__OW_NAMESPACE
-    delete process.env.__OW_API_HOST
-    delete process.env.__OW_ACTIVATION_ID
+    process.env.__OW_CLOUD = undefined
 
     expect(isInternalToAdobeRuntime()).toBeFalsy()
     jest.isolateModules(() => {
       const constants = require('../lib/constants')
       expect(constants.ENDPOINTS.prod).toEqual(constants.ENDPOINT_PROD)
       expect(constants.ENDPOINTS.stage).toEqual(constants.ENDPOINT_STAGE)
+    })
+  })
+
+  test('in runtime context - endpoints should be internal (ensure order of tests does not matter)', () => {
+    process.env.__OW_CLOUD = 'aws'
+
+    expect(isInternalToAdobeRuntime()).toBeTruthy()
+    jest.isolateModules(() => {
+      const constants = require('../lib/constants')
+      expect(constants.ENDPOINTS.prod).toEqual(constants.ENDPOINT_PROD_INTERNAL)
+      expect(constants.ENDPOINTS.stage).toEqual(constants.ENDPOINT_STAGE_INTERNAL)
     })
   })
 })


### PR DESCRIPTION

## Description

This allows state to run (as external) in the dev command

## Related Issue

[ACNA-3149](https://jira.corp.adobe.com/browse/ACNA-3149)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
